### PR TITLE
Release v4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [4.0.3] - 26.08.2026
+
+### Fixed
+
+- WebView success callback after 3DS — the payment screen stayed open and `PaymentContract` never returned a result
+
 ## [4.0.2] - 13.08.2026
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ constructed parts and some can't.
 #### 1) Add the dependency in the project:
 Add following dependency in `build.gradle`:
 
-```implementation 'com.tranzzo.android:payment_merchant:4.0.2'```.
+```implementation 'com.tranzzo.android:payment_merchant:4.0.3'```.
 
 Add following code to your `settings.gradle` file in `repositories` section:
 ```groovy

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.tranzzo.android:payment_merchant:4.0.2'
+    implementation 'com.tranzzo.android:payment_merchant:4.0.3'
     implementation "androidx.constraintlayout:constraintlayout:$constraint_version"
     implementation "androidx.core:core-ktx:$core_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"


### PR DESCRIPTION
Bump the Tranzzo Payment SDK from `4.0.2` to `4.0.3`.

## SDK changes in 4.0.3

### Fixed
- WebView success callback after 3DS — the payment screen stayed open and `PaymentContract` never returned a result

## Changes in this repository

- `app/build.gradle` — dependency bumped to `com.tranzzo.android:payment_merchant:4.0.3`
- `README.md` — installation snippet updated to `4.0.3`
- `CHANGELOG.md` — new `[4.0.3] - 26.08.2026` entry

No other project changes are required — the toolchain, minimum requirements (compileSdk 36, JDK 17, Kotlin 2.0+, minSdk 23) and the example code are unchanged.

## Verification

Dependency resolution against Nexus could not be verified locally — the merchant repository requires credentials that are not configured in this environment (anonymous requests return HTTP 401 for both `4.0.2` and `4.0.3`). Earlier versions resolve only from the local Gradle cache. Please confirm CI resolves `4.0.3` before merging.